### PR TITLE
Use AI to craft email drafts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 google-api-python-client==1.7.8
 google-auth-httplib2==0.0.3
 google-auth-oauthlib==0.4.0
+openai>=1.0.0

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -37,7 +37,8 @@ class TestCreateDraft(unittest.TestCase):
 class TestCheckUnreadAndDraft(unittest.TestCase):
     @patch("mail.time.sleep", side_effect=StopIteration)
     @patch("mail.create_draft")
-    def test_check_unread_and_draft(self, mock_create_draft, mock_sleep):
+    @patch("mail.generate_reply", return_value="AI reply")
+    def test_check_unread_and_draft(self, mock_generate_reply, mock_create_draft, mock_sleep):
         service = MagicMock()
         service.users.return_value.messages.return_value.list.return_value.execute.return_value = {
             "messages": [{"id": "m1"}]
@@ -58,12 +59,13 @@ class TestCheckUnreadAndDraft(unittest.TestCase):
         service.users.return_value.messages.return_value.list.assert_called_once_with(
             userId="me", labelIds=["UNREAD"], maxResults=10
         )
+        mock_generate_reply.assert_called_once_with("sender@example.com", "Test")
         mock_create_draft.assert_called_once_with(
             service,
             "me",
             "sender@example.com",
             "Re: Test",
-            "Thank you for your email.",
+            "AI reply",
             thread_id="t1",
         )
 


### PR DESCRIPTION
## Summary
- add `openai` dependency
- implement `generate_reply` using OpenAI
- call `generate_reply` from `check_unread_and_draft`
- update unit tests for new behaviour

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849dc0638f88327b2f215509c0e8180