### PR TITLE
Document OpenAI API key requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ This simple script checks a Gmail inbox for unread messages and drafts a reply t
 2. Download the `credentials.json` file and place it in the project root.
 3. The first time you run the script, a browser window will open to authorize access to Gmail. A `token.json` file will be generated and saved for future runs.
 
+## OpenAI API Key
+
+Draft replies are generated using the OpenAI API. Set the `OPENAI_API_KEY` environment variable with your key before running the responder.
+
 ## Usage
 
 Run the responder with Python:


### PR DESCRIPTION
## Summary
- add OpenAI API key instructions after the setup section in README

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849e11b326c83278005ee0f64902fa9