### PR TITLE
Disable discovery caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ This simple script checks a Gmail inbox for unread messages and drafts a reply t
 1. In the [Google Cloud Console](https://console.cloud.google.com/), create OAuth client credentials for a desktop application.
 2. Download the `credentials.json` file and place it in the project root.
 3. The first time you run the script, a browser window will open to authorize access to Gmail. A `token.json` file will be generated and saved for future runs.
+4. The Gmail service is built with discovery caching disabled to avoid writing
+   cache files to disk.
 
 ## Usage
 

--- a/mail.py
+++ b/mail.py
@@ -131,7 +131,7 @@ def main() -> None:
             token.write(creds.to_json())
 
     try:
-        service = build("gmail", "v1", credentials=creds)
+        service = build("gmail", "v1", credentials=creds, cache_discovery=False)
         check_unread_and_draft(service, interval=args.interval, max_results=args.max_results)
     except HttpError as error:
         logging.error("An error occurred: %s", error)


### PR DESCRIPTION
## Summary
- disable Google API discovery caching in `mail.py`
- document that discovery caching is disabled in `README`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849e115ac1c8327921acf4e158ab89b